### PR TITLE
Update icon_expr Value in controlpanel.xml

### DIFF
--- a/src/plone/app/imaging/profiles/default/controlpanel.xml
+++ b/src/plone/app/imaging/profiles/default/controlpanel.xml
@@ -3,7 +3,7 @@
     xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="plone">
  <configlet title="Image Handling" action_id="ImagingSettings" appId="ImagingSettings"
     category="Products" condition_expr=""
-    icon_expr="string:$portal_url/image_icon.gif"
+    icon_expr="string:$portal_url/image_icon.png"
     url_expr="string:${portal_url}/@@imaging-controlpanel" visible="True"
     i18n:attributes="title">
   <permission>Plone Site Setup: Imaging</permission>


### PR DESCRIPTION
This tries to make control panel icon not broken in Plone 5.
