### PR TITLE
Backporting the auto CSRF protection from 1.1 branch

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,10 +1,16 @@
 [buildout]
-extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-3.x.cfg
+develop = .
+extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-4.x.cfg
 extensions = mr.developer
 package-name = plone.app.imaging
 package-extras = [test]
 sources-dir = extras
 auto-checkout = *
+
+[versions]
+plone.app.imaging =
+# plone.protect = 3.0.0
+# plone.keyring = 3.0.0
 
 [sources]
 plone.scale = git https://github.com/plone/plone.scale.git

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
   when they are accessed via UID-based URLs.
   [davisagli]
 
+- Backporting the auto CSRF protection from 1.1 branch
+  [keul]
+
 1.0.10 (2014-01-27)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name = name,
       ],
       extras_require = {'test':
           ['collective.testcaselayer',
+           'Products.PloneTestCase',
            'Products.ATContentTypes' ]},
       platforms = 'Any',
       zip_safe = False,

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name = name,
         'setuptools',
         'plone.scale [storage]',
         'z3c.caching',
+        'five.globalrequest',
       ],
       extras_require = {'test':
           ['collective.testcaselayer',

--- a/src/plone/app/imaging/traverse.py
+++ b/src/plone/app/imaging/traverse.py
@@ -1,4 +1,3 @@
-import logging
 from zope.component import adapts
 from zope.globalrequest import getRequest
 from zope.interface import implements
@@ -8,14 +7,17 @@ from Products.Archetypes.interfaces import IImageField
 from Products.Archetypes.Field import HAS_PIL
 from ZODB.POSException import ConflictError
 from ZPublisher.BaseRequest import DefaultPublishTraverse
+from pkg_resources import get_distribution
 from plone.app.imaging.interfaces import IBaseObject
 from plone.app.imaging.interfaces import IImageScaleHandler
 from plone.app.imaging.scale import ImageScale
+import logging
 
-try:
+
+if get_distribution('plone.protect').version >= '3.0.0':
     from plone.protect.interfaces import IDisableCSRFProtection
-    HAS_AUTO_CSRF = True
-except ImportError:
+    HAS_AUTO_CSRF = true
+else:
     logging.info("plone.protect < 3.0.0 no auto csrf protection")
     HAS_AUTO_CSRF = False
 

--- a/src/plone/app/imaging/traverse.py
+++ b/src/plone/app/imaging/traverse.py
@@ -16,7 +16,7 @@ import logging
 
 if get_distribution('plone.protect').version >= '3.0.0':
     from plone.protect.interfaces import IDisableCSRFProtection
-    HAS_AUTO_CSRF = true
+    HAS_AUTO_CSRF = True
 else:
     logging.info("plone.protect < 3.0.0 no auto csrf protection")
     HAS_AUTO_CSRF = False


### PR DESCRIPTION
The CSRF protection added in the PLIP 13679 (https://dev.plone.org/ticket/13679) could be also backported to Plone 4 (Plone need some fix, but it's working).

This fix will make plone.app.imaging working with recent plone.protect without side effects.
