### PR TITLE
disable csrf protection when scale is generated and traversed to

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Disable csrf protection when scale is generated and traversed to.
+  [vangheem]
 
 
 1.0.12 (2015-11-26)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name = name,
         'setuptools',
         'plone.scale [storage]',
         'z3c.caching',
+        'five.globalrequest'
       ],
       extras_require = {'test':
           ['collective.testcaselayer',

--- a/src/plone/app/imaging/traverse.py
+++ b/src/plone/app/imaging/traverse.py
@@ -9,6 +9,9 @@ from ZPublisher.BaseRequest import DefaultPublishTraverse
 from plone.app.imaging.interfaces import IBaseObject
 from plone.app.imaging.interfaces import IImageScaleHandler
 from plone.app.imaging.scale import ImageScale
+from plone.protect.interfaces import IDisableCSRFProtection
+from zope.interface import alsoProvides
+from zope.globalrequest import getRequest
 
 
 class ImageTraverser(DefaultPublishTraverse):
@@ -60,6 +63,10 @@ class DefaultImageScaleHandler(object):
     def createScale(self, instance, scale, width, height, data=None):
         """ create & return a scaled version of the image as retrieved
             from the field or optionally given data """
+        # disable CRSF on scale generation
+        req = getRequest()
+        if req:
+            alsoProvides(req, IDisableCSRFProtection)
         field = self.context
         if HAS_PIL and width and height:
             if data is None:


### PR DESCRIPTION
Backport CSRF fix to 4.3.x

Same as #19 but now the branch is on plone repository already.