### PR TITLE
Fixed 404 NotFound error when accessing image scales via webdav.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Fixes:
+
+- Fixed 404 NotFound error when accessing image scales via webdav.
+  [maurits]
 
 
 1.0.11 (2014-10-22)

--- a/src/plone/app/imaging/scaling.py
+++ b/src/plone/app/imaging/scaling.py
@@ -50,11 +50,14 @@ class ImageScaleFactory(object):
 class ImageScaling(BrowserView):
     """ view used for generating (and storing) image scales """
     implements(IImageScaling, ITraversable, IPublishTraverse)
+    # Ignore some stacks to help with accessing via webdav, otherwise you get a
+    # 404 NotFound error.
+    _ignored_stacks = ('manage_DAVget', 'manage_FTPget')
 
     def publishTraverse(self, request, name):
         """ used for traversal via publisher, i.e. when using as a url """
         stack = request.get('TraversalRequestNameStack')
-        if stack:
+        if stack and stack[-1] not in self._ignored_stacks:
             # field and scale name were given...
             scale = stack.pop()
             image = self.scale(name, scale)             # this is aq-wrapped
@@ -207,10 +210,14 @@ class ImageScaling(BrowserView):
 
     def getAvailableSizes(self, fieldname=None):
         field = self.field(fieldname)
+        if field is None:
+            return {}
         return field.getAvailableSizes(self.context)
 
     def getImageSize(self, fieldname=None):
         field = self.field(fieldname)
+        if field is None:
+            return (0, 0)
         return field.getSize(self.context)
 
     def getInfo(self, fieldname=None, scale=None, height=None, width=None,

--- a/src/plone/app/imaging/tests/test_new_scaling.py
+++ b/src/plone/app/imaging/tests/test_new_scaling.py
@@ -110,6 +110,28 @@ class ImagePublisherTests(ImagingFunctionalTestCase):
         self.assertEqual(response.getHeader('Content-Type'), 'image/jpeg')
         self.assertImage(response.getBody(), 'JPEG', (64, 64))
 
+    def testPublishWebDavScaleViaUID(self):
+        scale = self.view.scale('image', width=64, height=64)
+        # make sure the referenced image scale is available
+        url = scale.url.replace('http://nohost', '') + '/manage_DAVget'
+        response = self.publish(url, basic=self.getCredentials())
+        self.assertEqual(response.getStatus(), 200)
+        # We get a very different response.  In the end it works out.
+        self.assertEqual(response.getHeader('Content-Type'),
+                         'text/plain; charset=iso-8859-15')
+        self.assertImage(response.getBody(), 'JPEG', (64, 64))
+
+    def testPublishFTPScaleViaUID(self):
+        scale = self.view.scale('image', width=64, height=64)
+        # make sure the referenced image scale is available
+        url = scale.url.replace('http://nohost', '') + '/manage_FTPget'
+        response = self.publish(url, basic=self.getCredentials())
+        self.assertEqual(response.getStatus(), 200)
+        # We get a very different response.  In the end it works out.
+        self.assertEqual(response.getHeader('Content-Type'),
+                         'text/plain; charset=iso-8859-15')
+        self.assertImage(response.getBody(), 'JPEG', (64, 64))
+
     def testPublishThumbViaUID(self):
         scale = self.view.scale('image', 'thumb')
         # make sure the referenced image scale is available
@@ -167,6 +189,16 @@ class ImagePublisherTests(ImagingFunctionalTestCase):
         url = url.replace('.jpeg', 'x.jpeg')
         response = self.publish(url, basic=self.getCredentials())
         self.assertEqual(response.getStatus(), 404)
+
+    def testPublishScaleWithInvalidScale(self):
+        scale = self.view.scale('image', 'no-such-scale')
+        self.assertEqual(scale, None)
+
+    def test_getAvailableSizesWithInvalidScale(self):
+        self.assertEqual(self.view.getAvailableSizes('no-such-scale'), {})
+
+    def test_getImageSizeWithInvalidScale(self):
+        self.assertEqual(self.view.getImageSize('no-such-scale'), (0, 0))
 
 
 class ScalesAdapterTests(ImagingTestCase):


### PR DESCRIPTION
Should be done on master as well, but let's first check it on 1.0.x (Plone 4.3).