### PR TITLE
Handled scale traversal correctly in five.pt (chameleon) - master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New:
 
 Fixes:
 
+- Fixed incompatibilities with five.pt and chameleon (closes `#16`_).
+  [rodfersou, maurits]
+
 - Fixed 404 NotFound error when accessing image scales via webdav.
   [maurits]
 
@@ -268,3 +271,5 @@ Fixes:
 
 - Initial package structure.
   [zopeskel]
+
+.. _`#16`: https://github.com/plone/plone.app.imaging/issues/16

--- a/src/plone/app/imaging/tests/test_new_scaling.py
+++ b/src/plone/app/imaging/tests/test_new_scaling.py
@@ -3,12 +3,24 @@ from plone.app.imaging.tests.base import ImagingFunctionalTestCase
 from plone.app.imaging.tests.base import getSettings
 from plone.app.imaging.scaling import ImageScaling
 from re import match
-
+from unittest import defaultTestLoader
 
 import transaction
 
 
-class ImageTraverseTests(ImagingTestCase):
+class ImageStandardTraverseTests(ImagingTestCase):
+    # Note: this class is subclassed by ImageChameleonTraverseTests, which
+    # inherits our tests but uses a different traverser.  We use the standard
+    # Zope pagetemplate traverser.
+
+    def traverser(self, view, path=''):
+        # Standard Zope page template traversal uses a list as path.
+        # This is a simplified version specialised for the scaling view.
+        stack = path.split('/')
+        while stack:
+            name = stack.pop(0)
+            view = view.traverse(name, stack)
+        return view
 
     def afterSetUp(self):
         self.data = self.getImage()
@@ -19,9 +31,7 @@ class ImageTraverseTests(ImagingTestCase):
 
     def traverse(self, path=''):
         view = self.image.unrestrictedTraverse('@@images')
-        stack = path.split('/')
-        name = stack.pop(0)
-        tag = view.traverse(name, stack)
+        tag = self.traverser(view, path)
         base = self.image.absolute_url()
         expected = r'<img src="%s/@@images/([-0-9a-f]{36}).(jpeg|gif|png)" ' \
             r'alt="foo" title="foo" height="(\d+)" width="(\d+)" />' % base
@@ -71,6 +81,35 @@ class ImageTraverseTests(ImagingTestCase):
         self.assertEqual(width, 42)
         self.assertEqual(height, 42)
         self.assertNotEqual(uid1, uid2, 'scale not updated?')
+
+
+class ImageChameleonTraverseTests(ImageStandardTraverseTests):
+    # This class inherits all test methods from its parent, but uses the
+    # Chameleon/five.pt traverser.
+
+    def traverser(self, view, path=''):
+        # five.pt/chameleon uses a tuple as path.  This is a simplified
+        # version of BoboAwareZopeTraverse.traverse from five.pt.expressions,
+        # specialised for the scaling view.
+        path_items = tuple(path.split('/'))
+        length = len(path_items)
+        if length:
+            i = 0
+            while i < length:
+                name = path_items[i]
+                i += 1
+                view = view.traverse(name, path_items[i:])
+        return view
+
+
+class ImageTagTests(ImagingTestCase):
+
+    def afterSetUp(self):
+        self.data = self.getImage()
+        self.image = self.folder[self.folder.invokeFactory(
+            'Image', id='foo', image=self.data)]
+        field = self.image.getField('image')
+        self.available = field.getAvailableSizes(self.image)
 
     def testViewTagMethod(self):
         folder = self.folder
@@ -313,3 +352,7 @@ class ScalesAdapterTests(ImagingTestCase):
 
     def testGetImageSize(self):
         assert self.adapter.getImageSize('image') == (200, 200)
+
+
+def test_suite():
+    return defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This is the master variant of pull request #18, which it cherry picks. This supersedes pull request #17.

I have just seen that plone.namedfile has already solved this problem in a different way.  It introduces a class `ImmutableTraverser` which it prepares with the correct scale. See
https://github.com/plone/plone.namedfile/blob/3.0.4/plone/namedfile/scaling.py#L117
and
https://github.com/plone/plone.namedfile/blob/3.0.4/plone/namedfile/scaling.py#L175

What we do in this pull request is similar. Instead of an `ImmutableTraverser` instance with a preset `scale` property, we return an instance of the `ImageScaling` browser view (`self`) with a preset `_image_fieldname` property.