### PR TITLE
plone.app.imaging doesn't actually require plone.app.controlpanel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Add coding headers on python files.
   [gforcada]
 
+- Remove vestigial requirement of plone.app.controlpanel.
+  [davisagli]
+
+
 2.0.5 (2016-08-17)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(name = name,
       include_package_data = True,
       install_requires = [
           'setuptools',
-          'plone.app.controlpanel',
           'plone.scale [storage]',
           'Products.Archetypes',
           'z3c.caching',


### PR DESCRIPTION
This entry in install_requires is left over from before.