### PR TITLE
Catch potentially site-bricking error caused by improperly formatted …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- catch errors caused by invalid image scale
+  [obct537]
 
 
 2.0.6 (2016-12-19)

--- a/src/plone/app/imaging/utils.py
+++ b/src/plone/app/imaging/utils.py
@@ -20,9 +20,12 @@ def getAllowedSizes():
     for line in settings.allowed_sizes:
         line = line.strip()
         if line:
-            name, width, height = pattern.match(line).groups()
-            name = name.strip().replace(' ', '_')
-            sizes[name] = int(width), int(height)
+	    try:
+                name, width, height = pattern.match(line).groups()
+                name = name.strip().replace(' ', '_')
+                sizes[name] = int(width), int(height)
+	    except AttributeError:
+		continue
     return sizes
 
 


### PR DESCRIPTION
…image scale

Might not be the perfect approach here?

Fixes a major bug for us, in the event that someone inputs an improperly formatted scale.