### PR TITLE
fix(traverse): Image content w/ field_scale id

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix traversal handling of subobjects with ids that may also be image scales.
+  [rpatterson]
 
 
 1.0.14 (2019-10-09)

--- a/src/plone/app/imaging/profiles/testing/metadata.xml
+++ b/src/plone/app/imaging/profiles/testing/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1.0</version>
+</metadata>

--- a/src/plone/app/imaging/profiles/testing/types.xml
+++ b/src/plone/app/imaging/profiles/testing/types.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+ <object name="News Item Folder"
+    meta_type="Factory-based Type Information with dynamic views"/>
+</object>

--- a/src/plone/app/imaging/profiles/testing/types/News_Item_Folder.xml
+++ b/src/plone/app/imaging/profiles/testing/types/News_Item_Folder.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<object name="News Item Folder"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="title" i18n:translate="">News Item Folder</property>
+ <property name="description"
+     i18n:translate="">An announcement that will show up in news listings.</property>
+ <property name="icon_expr"></property>
+ <property name="content_meta_type">ATNewsItemFolder</property>
+ <property name="product">plone.app.imaging.tests</property>
+ <property name="factory">addATNewsItemFolder</property>
+ <property name="immediate_view">newsitem_view</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">False</property>
+ <property name="allowed_content_types"/>
+ <property name="allow_discussion">False</property>
+ <property name="default_view">newsitem_view</property>
+ <property name="view_methods">
+  <element value="newsitem_view"/>
+ </property>
+ <alias from="(Default)" to="(dynamic view)"/>
+ <alias from="edit" to="atct_edit"/>
+ <alias from="sharing" to="@@sharing"/>
+ <alias from="view" to="(selected layout)"/>
+ <action title="View" action_id="view" category="object" condition_expr=""
+    url_expr="string:${object_url}" visible="True"
+    i18n:attributes="title">
+  <permission value="View"/>
+ </action>
+ <action title="Edit" action_id="edit" category="object" condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+    url_expr="string:${object_url}/edit" visible="True"
+    i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+ <action title="History" action_id="history" category="object"
+    condition_expr="" url_expr="string:${object_url}/atct_history"
+    visible="False" i18n:attributes="title">
+  <permission value="ATContentTypes: View history"/>
+ </action>
+ <action title="External Edit" action_id="external_edit" category="object"
+    condition_expr="object/externalEditorEnabled"
+    url_expr="string:${object_url}/external_edit" visible="False"
+    i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+</object>

--- a/src/plone/app/imaging/testing.py
+++ b/src/plone/app/imaging/testing.py
@@ -1,6 +1,7 @@
 from Testing.ZopeTestCase import installPackage
 from Products.Five import zcml
 from Products.Five import fiveconfigure
+
 from collective.testcaselayer.ptc import BasePTCLayer, ptc_layer
 from plone.app.imaging.monkey import unpatchImageField
 
@@ -14,6 +15,7 @@ class ImagingLayer(BasePTCLayer):
         zcml.load_config('testing.zcml', imaging)
         fiveconfigure.debug_mode = False
         installPackage('plone.app.imaging', quiet=True)
+        installPackage('plone.app.imaging.tests')
         self.addProfile('plone.app.imaging:default')
 
     def beforeTearDown(self):

--- a/src/plone/app/imaging/testing.zcml
+++ b/src/plone/app/imaging/testing.zcml
@@ -1,11 +1,23 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="plone.app.imaging">
 
   <include package="plone.app.imaging" />
 
   <include zcml:condition="installed plone.app.blob"
       package="plone.app.blob.tests" file="testing.zcml" />
+
+  <five:registerPackage package=".tests" initialize=".tests.initialize" />
+
+  <genericsetup:registerProfile
+    name="testing"
+    title="plone.app.imaging.testing"
+    description="Additional set up and configuration for testing images"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
 
 </configure>

--- a/src/plone/app/imaging/tests/__init__.py
+++ b/src/plone/app/imaging/tests/__init__.py
@@ -1,1 +1,35 @@
-# non-empty init file to turn this directory into a module...
+"""
+Tests for Plone's imaging support.
+"""
+
+from Products.CMFCore.utils import ContentInit
+
+from . import newsitemfolder  # noqa
+
+PROJECTNAME = "plone.app.imaging.tests"
+
+permissions = {
+    "News Item Folder": "plone.app.imaging.tests: Add News Item Folder",
+}
+
+
+# Copied from Products.ATContentTypes
+def initialize(context):
+    from Products.Archetypes.atapi import process_types
+    from Products.Archetypes.atapi import listTypes
+
+    listOfTypes = listTypes(PROJECTNAME)
+
+    content_types, constructors, ftis = process_types(
+        listOfTypes,
+        PROJECTNAME)
+
+    allTypes = zip(content_types, constructors)
+    for atype, constructor in allTypes:
+        kind = "%s: %s" % (PROJECTNAME, atype.archetype_name)
+        ContentInit(
+            kind,
+            content_types=(atype,),
+            permission=permissions[atype.portal_type],
+            extra_constructors=(constructor,),
+            ).initialize(context)

--- a/src/plone/app/imaging/tests/base.py
+++ b/src/plone/app/imaging/tests/base.py
@@ -1,9 +1,16 @@
+"""
+Common, internal, `plone.app.imaging` testing support.
+"""
+
+import os
+from StringIO import StringIO
+
 from Products.Five.testbrowser import Browser
 from Products.PloneTestCase import ptc
 from plone.app.imaging import testing
 from plone.app.imaging.tests.utils import getData
-from StringIO import StringIO
 
+TESTS_PATH = os.path.dirname(__file__)
 
 ptc.setupPloneSite()
 

--- a/src/plone/app/imaging/tests/newsitemfolder.py
+++ b/src/plone/app/imaging/tests/newsitemfolder.py
@@ -1,0 +1,33 @@
+"""
+A folderish content type with an image field for testing such edge cases.
+"""
+
+from Products.ATContentTypes.content import schemata
+from Products.ATContentTypes.content import base
+from Products.ATContentTypes.content import folder
+from Products.ATContentTypes.content import newsitem
+
+ATNewsItemFolderSchema = (
+    folder.ATBTreeFolderSchema.copy() + newsitem.ATNewsItemSchema.copy()
+)
+
+schemata.finalizeATCTSchema(ATNewsItemFolderSchema)
+
+
+class ATNewsItemFolder(folder.ATBTreeFolder, newsitem.ATNewsItem):
+    """
+    A folderish content type with an image field for testing such edge cases.
+    """
+
+    schema = ATNewsItemFolderSchema
+
+    portal_type = 'News Item Folder'
+    archetype_name = 'News Item Folder'
+    _atct_newTypeFor = {
+        'portal_type': 'CMF News Item Folder',
+        'meta_type': 'News Item Folder',
+    }
+    assocFileExt = ()
+
+
+base.registerATCT(ATNewsItemFolder, "plone.app.imaging.tests")

--- a/src/plone/app/imaging/tests/traversal.txt
+++ b/src/plone/app/imaging/tests/traversal.txt
@@ -53,3 +53,47 @@ expression:
 
   >>> bool(eval_expression('exists:portal/foo/image_thumb'))
   True
+
+Content can be added with ids that correspond to field names and scales:
+
+  >>> import os
+  >>> import shutil
+  >>> from plone.app.imaging.tests import base
+  >>> test_image_scale_name = os.path.join(
+  ...     base.TESTS_PATH,
+  ...     "tmp",
+  ...     "image_thumb.jpg",
+  ... )
+  >>> shutil.copyfile(
+  ...     os.path.join(base.TESTS_PATH, "image.jpg"),
+  ...     test_image_scale_name,
+  ... )
+
+  >>> import __builtin__
+  >>> portal.portal_setup.runAllImportStepsFromProfile("plone.app.imaging:testing")
+  {...types: 'News Item Folder'...}
+  >>> with __builtin__.open(test_image_scale_name) as test_image_scale_name_opened:
+  ...     portal.invokeFactory(
+  ...         "News Item Folder",
+  ...         id="bar-folder",
+  ...         title="Bar Folder",
+  ...         image=test_image_scale_name_opened,
+  ...     )
+  'bar-folder'
+
+  >>> browser.handleErrors = False
+  >>> browser.open("http://nohost/plone/bar-folder/")
+  >>> browser.getLink(url="createObject?type_name=Image").click()
+  >>> with __builtin__.open(test_image_scale_name) as test_image_scale_name_opened:
+  ...     browser.getControl(name="id").value = "image_thumb"
+  ...     browser.getControl(name="image_file").add_file(
+  ...         test_image_scale_name_opened, "image/jpg", "image_thumb.jpg")
+  ...     browser.getControl("Save").click()
+  >>> browser.url
+  'http://nohost/plone/bar-folder/image_thumb/view'
+  >>> print(browser.contents)
+  <!DOCTYPE html>
+  <html...
+  >>> browser.open("http://nohost/plone/bar-folder/image_thumb")
+  >>> browser.contents
+  '\xff\xd8\xff\xe0\x00\x10JFIF...


### PR DESCRIPTION
Adds a test that reproduces a bug in the edge case where a user creates a new content
instance of the `Image` type that happens to have a `context.id` that matches the same
`{field}_{scale}` format that is introspected by the image scale traverser to try and
reproduce a bug in that logic.

Also adds a fix for the bug.  I went with a conditional at the top of
`plone.app.imaging.traverse:ImageTraverser.publishTraverse` because I'm not sure of all
the implications of just calling `self.fallback(request, name)` first, otherwise I would
have gone with that as it seems like the correct behavior to me.  So LMK if someone who
knows better than I also thinks that's the right approach and I'll make the change.

Due to [an unrelated
bug](https://github.com/plone/Products.CMFPlone/issues/2200#issuecomment-843632261), I
wasn't able to get this test to reproduce the bug on the latest applicable Plone that
still supports Archetypes, version 5.2 under Python 2.7.  I found it easiest to develop
the test case and fix against the branch used in the latest `buildout.coredev` branch
where `ATContentTypes` was the default, namely `4.3`.  Once we're done making changes to
the test and fix I'll also forward port this commit to the `5.0-5.2` branches.


----

This is probably my first contribution in years, so please LMK what's changed and what I
should do differently, thanks!