### PR TITLE
fix(traverse): Image content w/ field_scale id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix traversal handling of subobjects with ids that may also be image scales.
+  [rpatterson]
 
 
 2.0.8 (2019-10-09)

--- a/src/plone/app/imaging/profiles/testing/metadata.xml
+++ b/src/plone/app/imaging/profiles/testing/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1.0</version>
+</metadata>

--- a/src/plone/app/imaging/profiles/testing/types.xml
+++ b/src/plone/app/imaging/profiles/testing/types.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+ <object name="News Item Folder"
+    meta_type="Factory-based Type Information with dynamic views"/>
+</object>

--- a/src/plone/app/imaging/profiles/testing/types/News_Item_Folder.xml
+++ b/src/plone/app/imaging/profiles/testing/types/News_Item_Folder.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<object name="News Item Folder"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <property name="title" i18n:translate="">News Item Folder</property>
+ <property name="description"
+     i18n:translate="">An announcement that will show up in news listings.</property>
+ <property name="icon_expr"></property>
+ <property name="content_meta_type">ATNewsItemFolder</property>
+ <property name="product">plone.app.imaging.tests</property>
+ <property name="factory">addATNewsItemFolder</property>
+ <property name="immediate_view">newsitem_view</property>
+ <property name="global_allow">True</property>
+ <property name="filter_content_types">False</property>
+ <property name="allowed_content_types"/>
+ <property name="allow_discussion">False</property>
+ <property name="default_view">newsitem_view</property>
+ <property name="view_methods">
+  <element value="newsitem_view"/>
+ </property>
+ <alias from="(Default)" to="(dynamic view)"/>
+ <alias from="edit" to="atct_edit"/>
+ <alias from="sharing" to="@@sharing"/>
+ <alias from="view" to="(selected layout)"/>
+ <action title="View" action_id="view" category="object" condition_expr=""
+    url_expr="string:${object_url}" visible="True"
+    i18n:attributes="title">
+  <permission value="View"/>
+ </action>
+ <action title="Edit" action_id="edit" category="object" condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+    url_expr="string:${object_url}/edit" visible="True"
+    i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+ <action title="History" action_id="history" category="object"
+    condition_expr="" url_expr="string:${object_url}/atct_history"
+    visible="False" i18n:attributes="title">
+  <permission value="ATContentTypes: View history"/>
+ </action>
+ <action title="External Edit" action_id="external_edit" category="object"
+    condition_expr="object/externalEditorEnabled"
+    url_expr="string:${object_url}/external_edit" visible="False"
+    i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+</object>

--- a/src/plone/app/imaging/testing.py
+++ b/src/plone/app/imaging/testing.py
@@ -11,8 +11,9 @@ class ImagingFixture(PloneTestCaseFixture):
     def setUpZope(self, app, configurationContext):
         super(ImagingFixture, self).setUpZope(app, configurationContext)
         import plone.app.imaging
-        self.loadZCML(package=plone.app.imaging)
+        self.loadZCML(name='testing.zcml', package=plone.app.imaging)
         z2.installProduct(app, 'plone.app.imaging')
+        z2.installProduct(app, 'plone.app.imaging.tests')
 
     def setUpPloneSite(self, portal):
         super(ImagingFixture, self).setUpPloneSite(portal)

--- a/src/plone/app/imaging/testing.zcml
+++ b/src/plone/app/imaging/testing.zcml
@@ -1,11 +1,23 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="plone.app.imaging">
 
   <include package="plone.app.imaging" />
 
   <include zcml:condition="installed plone.app.blob"
       package="plone.app.blob.tests" file="testing.zcml" />
+
+  <five:registerPackage package=".tests" initialize=".tests.initialize" />
+
+  <genericsetup:registerProfile
+    name="testing"
+    title="plone.app.imaging.testing"
+    description="Additional set up and configuration for testing images"
+    for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
 
 </configure>

--- a/src/plone/app/imaging/tests/__init__.py
+++ b/src/plone/app/imaging/tests/__init__.py
@@ -1,2 +1,36 @@
 # -*- coding: utf-8 -*-
-# non-empty init file to turn this directory into a module...
+"""
+Tests for Plone's imaging support.
+"""
+
+from Products.CMFCore.utils import ContentInit
+
+from . import newsitemfolder  # noqa
+
+PROJECTNAME = "plone.app.imaging.tests"
+
+permissions = {
+    "News Item Folder": "plone.app.imaging.tests: Add News Item Folder",
+}
+
+
+# Copied from Products.ATContentTypes
+def initialize(context):
+    from Products.Archetypes.atapi import process_types
+    from Products.Archetypes.atapi import listTypes
+
+    listOfTypes = listTypes(PROJECTNAME)
+
+    content_types, constructors, ftis = process_types(
+        listOfTypes,
+        PROJECTNAME)
+
+    allTypes = zip(content_types, constructors)
+    for atype, constructor in allTypes:
+        kind = "%s: %s" % (PROJECTNAME, atype.archetype_name)
+        ContentInit(
+            kind,
+            content_types=(atype,),
+            permission=permissions[atype.portal_type],
+            extra_constructors=(constructor,),
+            ).initialize(context)

--- a/src/plone/app/imaging/tests/base.py
+++ b/src/plone/app/imaging/tests/base.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""
+Common, internal, `plone.app.imaging` testing support.
+"""
+
 from os.path import dirname
 from os.path import join
 from plone.app.imaging import testing
@@ -10,6 +14,8 @@ from plone.testing.z2 import Browser
 from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 from six import StringIO
 from zope.component import queryUtility
+
+TESTS_PATH = dirname(__file__)
 
 
 def getSettings():

--- a/src/plone/app/imaging/tests/newsitemfolder.py
+++ b/src/plone/app/imaging/tests/newsitemfolder.py
@@ -1,0 +1,33 @@
+"""
+A folderish content type with an image field for testing such edge cases.
+"""
+
+from Products.ATContentTypes.content import schemata
+from Products.ATContentTypes.content import base
+from Products.ATContentTypes.content import folder
+from Products.ATContentTypes.content import newsitem
+
+ATNewsItemFolderSchema = (
+    folder.ATBTreeFolderSchema.copy() + newsitem.ATNewsItemSchema.copy()
+)
+
+schemata.finalizeATCTSchema(ATNewsItemFolderSchema)
+
+
+class ATNewsItemFolder(folder.ATBTreeFolder, newsitem.ATNewsItem):
+    """
+    A folderish content type with an image field for testing such edge cases.
+    """
+
+    schema = ATNewsItemFolderSchema
+
+    portal_type = 'News Item Folder'
+    archetype_name = 'News Item Folder'
+    _atct_newTypeFor = {
+        'portal_type': 'CMF News Item Folder',
+        'meta_type': 'News Item Folder',
+    }
+    assocFileExt = ()
+
+
+base.registerATCT(ATNewsItemFolder, "plone.app.imaging.tests")

--- a/src/plone/app/imaging/tests/traversal.txt
+++ b/src/plone/app/imaging/tests/traversal.txt
@@ -62,3 +62,48 @@ expression:
 
   >>> bool(eval_expression('exists:portal/foo/image_thumb'))
   True
+
+Content can be added with ids that correspond to field names and scales:
+
+  >>> import os
+  >>> import shutil
+  >>> from plone.app.imaging.tests import base
+  >>> test_image_scale_name = os.path.join(
+  ...     base.TESTS_PATH,
+  ...     "tmp",
+  ...     "image_thumb.jpg",
+  ... )
+  >>> shutil.copyfile(
+  ...     os.path.join(base.TESTS_PATH, "image.jpg"),
+  ...     test_image_scale_name,
+  ... )
+
+  >>> import __builtin__
+  >>> portal.portal_setup.runAllImportStepsFromProfile("plone.app.imaging:testing")
+  {...types: 'News Item Folder'...}
+  >>> with __builtin__.open(test_image_scale_name) as test_image_scale_name_opened:
+  ...     portal.invokeFactory(
+  ...         "News Item Folder",
+  ...         id="bar-folder",
+  ...         title="Bar Folder",
+  ...         image=test_image_scale_name_opened,
+  ...     )
+  'bar-folder'
+  >>> commit()
+
+  >>> browser.handleErrors = False
+  >>> browser.open("http://nohost/plone/bar-folder/")
+  >>> browser.getLink(url="createObject?type_name=Image").click()
+  >>> with __builtin__.open(test_image_scale_name) as test_image_scale_name_opened:
+  ...     browser.getControl(name="id").value = "image_thumb"
+  ...     browser.getControl(name="image_file").add_file(
+  ...         test_image_scale_name_opened, "image/jpg", "image_thumb.jpg")
+  ...     browser.getControl("Save").click()
+  >>> browser.url
+  'http://nohost/plone/bar-folder/image_thumb/view'
+  >>> print(browser.contents)
+  <!DOCTYPE html>
+  <html...
+  >>> browser.open("http://nohost/plone/bar-folder/image_thumb")
+  >>> browser.contents
+  '\xff\xd8\xff\xe0\x00\x10JFIF...

--- a/src/plone/app/imaging/traverse.py
+++ b/src/plone/app/imaging/traverse.py
@@ -1,18 +1,22 @@
 # -*- coding: utf-8 -*-
 from logging import exception
+
 from zope.component import adapts
 from zope.interface import implementer
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
 from zope.publisher.interfaces import IRequest
-from Products.Archetypes.interfaces import IImageField
-from Products.Archetypes.Field import HAS_PIL
+
 from ZODB.POSException import ConflictError
 from ZPublisher.BaseRequest import DefaultPublishTraverse
+from OFS import interfaces as ofs_ifaces
+
+from Products.Archetypes.interfaces import IImageField
+from Products.Archetypes.Field import HAS_PIL
 from plone.app.imaging.interfaces import IBaseObject
 from plone.app.imaging.interfaces import IImageScaleHandler
 from plone.app.imaging.scale import ImageScale
 from plone.protect.interfaces import IDisableCSRFProtection
-from zope.interface import alsoProvides
-from zope.globalrequest import getRequest
 
 
 import six
@@ -26,6 +30,12 @@ class ImageTraverser(DefaultPublishTraverse):
         return super(ImageTraverser, self).publishTraverse(request, name)
 
     def publishTraverse(self, request, name):
+        if (
+                ofs_ifaces.IObjectManager.providedBy(self.context)
+                and name in self.context.objectIds()
+        ):
+            # The name is for an actual subobject of this folderish context.
+            return self.fallback(request, name)
         schema = self.context.Schema()
         if '_' in name:
             fieldname, scale = name.split('_', 1)


### PR DESCRIPTION
Adds a test that reproduces a bug in the edge case where a user creates a new content
instance of the `Image` type that happens to have a `context.id` that matches the same
`{field}_{scale}` format that is introspected by the image scale traverser to try and
reproduce a bug in that logic.

Also adds a fix for the bug.  I went with a conditional at the top of
`plone.app.imaging.traverse:ImageTraverser.publishTraverse` because I'm not sure of all
the implications of just calling `self.fallback(request, name)` first, otherwise I would
have gone with that as it seems like the correct behavior to me.  So LMK if someone who
knows better than I also thinks that's the right approach and I'll make the change.

Due to [an unrelated
bug](https://github.com/plone/Products.CMFPlone/issues/2200#issuecomment-843632261), I
wasn't able to get this test to reproduce the bug on the latest applicable Plone that
still supports Archetypes, version 5.2 under Python 2.7.  I found it easiest to develop
the test case and fix against the branch used in the latest `buildout.coredev` branch
where `ATContentTypes` was the default, namely `4.3`.  Once we're done making changes to
the test and fix I'll also forward port this commit to the `5.0-5.2` branches.


----

Corresponding PR for [an already reviewed and merged PR](https://github.com/plone/plone.app.imaging/pull/41#issuecomment-853434222).