### PR TITLE
test(traverse): Fix clean checkout test error

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,14 +13,6 @@ Bug fixes:
 1.0.15 (2021-06-11)
 -------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
 - Fix traversal handling of subobjects with ids that may also be image scales.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.0.16 (unreleased)
 -------------------
 
-- Nothing changed yet.
+Bug fixes:
+
+- Fix clean checkout error in scale traverser tests.
+  [rpatterson]
 
 
 1.0.15 (2021-06-11)

--- a/src/plone/app/imaging/tests/tmp/.gitignore
+++ b/src/plone/app/imaging/tests/tmp/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore


### PR DESCRIPTION
There was [a clean checkout
issue](https://github.com/plone/plone.app.imaging/pull/42#issuecomment-859899613) with
my `./src/plone/app/imaging/tests/tmp/.gitignore` usage that resulted in false positives
for me locally. I was able to reproduce the issue, confirmed this fixes it.